### PR TITLE
Improve spooky check

### DIFF
--- a/sas.sh
+++ b/sas.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-VERSION=0.5
+VERSION=0.6
 
 ADD_DIR=""
 ALLOW_BINDIR=0
@@ -163,6 +163,8 @@ _is_spooky() {
 		""           |\
 		"/"          |\
 		*//*         |\
+		*./*         |\
+		*..*         |\
 		"/home"      |\
 		"/var/home"  |\
 		"$HOME"      |\
@@ -186,8 +188,11 @@ _is_spooky() {
 		"$ZDOTDIR"   )
 			return 1
 			;;
-		*)
+		/*)  # make sure valid paths start with /
 			return 0
+			;;
+		*)
+			return 1
 			;;
 	esac
 }
@@ -221,8 +226,6 @@ _check_userdir() {
 
 	dir="$(eval echo \$XDG_$1_DIR)"
 	if [ -z "$dir" ]; then
-		return 1
-	elif ! _is_spooky "$dir"; then
 		return 1
 	fi
 	echo "$dir"
@@ -456,12 +459,12 @@ if [ -z "$USER" ] || [ ! -d "$HOME" ] || [ -z "$ID" ]; then
 fi
 
 # get xdg vars
-BINDIR="$(readlink -f "${XDG_BIN_HOME:-$HOME/.local/bin}")"
-DATADIR="$(readlink -f "${XDG_DATA_HOME:-$HOME/.local/share}")"
-CONFIGDIR="$(readlink -f "${XDG_CONFIG_HOME:-$HOME/.config}")"
-CACHEDIR="$(readlink -f "${XDG_CACHE_HOME:-$HOME/.cache}")"
-STATEDIR="$(readlink -f "${XDG_STATE_HOME:-$HOME/.local/state}")"
-RUNDIR="$(readlink -f "${XDG_RUNTIME_DIR:-/run/user/$ID}")"
+BINDIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
+CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+STATEDIR="${XDG_STATE_HOME:-$HOME/.local/state}"
+RUNDIR="${XDG_RUNTIME_DIR:-/run/user/$ID}"
 
 # check xdg user dirs, if they are spooky we use their default value
 APPLICATIONSDIR="$(_check_userdir APPLICATIONS || echo ~/Applications)"
@@ -476,7 +479,7 @@ TEMPLATESDIR="$(   _check_userdir TEMPLATES    || echo ~/Templates)"
 VIDEOSDIR="$(      _check_userdir VIDEOS       || echo ~/Videos)"
 
 # check xdg base dir vars are not some odd value
-_check_xdgbase $XDG_BASE_DIRS
+_check_xdgbase $XDG_BASE_DIRS $XDG_APPLICATION_DIRS
 
 ZDOTDIR="$(readlink -f "${ZDOTDIR:-$HOME}")"
 TMPDIR="${TMPDIR:-/tmp}"

--- a/sas.sh
+++ b/sas.sh
@@ -154,29 +154,36 @@ _is_target() {
 }
 
 _is_spooky() {
-	case "$(readlink -f "$1")" in
-		""              |\
-		"/"             |\
-		"/home"         |\
-		"/var/home"     |\
-		"$HOME"         |\
-		"/run"          |\
-		"/dev"          |\
-		"/proc"         |\
-		"/mnt"          |\
-		"/media"        |\
-		~/.local        |\
-		~/.firefox      |\
-		~/.gnupg        |\
-		~/.mozilla      |\
-		~/.ssh          |\
-		~/.vim          |\
-		~/.bashrc       |\
-		~/.profile      |\
-		~/.bash_profile |\
-		~/.zshrc        |\
-		~/.zprofile     |\
-		"$ZDOTDIR"      )
+	to_check="$1"
+	if [ -L "$to_check" ]; then
+		to_check="$(readlink -f "$to_check")"
+	fi
+
+	case "$to_check" in
+		""           |\
+		"/"          |\
+		*//*         |\
+		"/home"      |\
+		"/var/home"  |\
+		"$HOME"      |\
+		"/run"       |\
+		"/dev"       |\
+		"/proc"      |\
+		"/mnt"       |\
+		"/media"     |\
+		*.local      |\
+		*.firefox    |\
+		*.firedragon |\
+		*.zen        |\
+		*.gnupg      |\
+		*.mozilla    |\
+		*.ssh        |\
+		*.vim        |\
+		*.profile    |\
+		*.bash*      |\
+		*.zsh*       |\
+		*fish        |\
+		"$ZDOTDIR"   )
 			return 1
 			;;
 		*)


### PR DESCRIPTION
@fiftydinar I found a problem with `BINDIR="$(readlink -f "${XDG_BIN_HOME:-$HOME/.local/bin}")"` and similar. 

If I happen to declare `XDG_BIN_HOME=kek`, the readlink will interpret that as a relative location and expand that to `/home/$USER/kek` for example, that's a problem since the spec says that relative locations are [not allowed](https://specifications.freedesktop.org/basedir-spec/latest/) and we should ignore the variable when that happens.

```
All paths set in these environment variables must be absolute. If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it. 
```

This also means that I can't run `_is_spooky` in `_check_userdir` like I was doing before, because if we for example have `XDG_DOWNLOAD_DIR` not declared, the script assumes the default of `~/Downloads` **this means it never checks if `~/Downloads` is a symlink to spooky location**

So now instead I added `$XDG_APPLICATION_DIRS` to `_check_xdgbase` to also cover that. 

Let me know if I broke anything. Now `_is_spooky` will only run `readlink` if the path is indeed a symlink, else I made sure to fail paths that contain stuff like `//` `./` `..`


