### PR TITLE
Use normal home as `SAS_HOME` instead

### DIFF
--- a/sas.sh
+++ b/sas.sh
@@ -493,7 +493,7 @@ _dep_check $DEPENDENCIES
 # Make sure we always have the real home
 USER="${LOGNAME:-${USER:-${USERNAME}}}"
 if [ -f '/etc/passwd' ]; then
-	SAS_HOME="$(readlink -f "$(_get_sys_info home)")"
+	SAS_HOME="$(_get_sys_info home)"
 	SAS_ID="$(_get_sys_info id)"
 	# export internal variables this way apps with
 	# restricted access to /etc can still use this


### PR DESCRIPTION
It fixes the issue of file picker not seeing `/var/home` xdg dirs, like Music in DeadBeeF while not breaking anything.