### PR TITLE
optimize yet again, refactor, give exec perms temporarily when `--trust-once` is used

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -32,7 +32,6 @@ jobs:
 
         BWRAP_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/bubblewrap/official/bwrap/raw.dl"
         AWK_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/mawk/mawk/raw.dl"
-        BUSYBOX_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/busybox/nixpkgs/busybox/raw.dl"
         SQUASHFUSE_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/squashfuse/nixpkgs/squashfuse/raw.dl"
         
         mkdir -p ./AppDir/bin
@@ -40,18 +39,10 @@ jobs:
         cd ./AppDir
 
         wget --retry-connrefused --tries=30 "$AWK_URL"        -O  ./bin/awk
-        wget --retry-connrefused --tries=30 "$BUSYBOX_URL"    -O  ./busybox
         wget --retry-connrefused --tries=30 "$BWRAP_URL"      -O  ./bin/bwrap
         wget --retry-connrefused --tries=30 "$SQUASHFUSE_URL" -O  ./bin/squashfuse
 
-        ln -s ../busybox ./bin/cksum
-        ln -s ../busybox ./bin/grep
-        ln -s ../busybox ./bin/head
-        ln -s ../busybox ./bin/od
-        ln -s ../busybox ./bin/readlink
-        ln -s ../busybox ./bin/tail
-
-        chmod +x ./AppRun ./busybox ./bin/*
+        chmod +x ./AppRun ./bin/*
         
         VERSION="$(./AppRun --version)"
         [ -n "$VERSION" ]

--- a/sas.sh
+++ b/sas.sh
@@ -122,14 +122,6 @@ _dep_check() {
 	done
 }
 
-# Warn about slow shell
-_check_shell() {
-	sys_shell="$(readlink -f '/bin/sh' 2>/dev/null)"
-	if [ "${sys_shell##*/}" = "bash" ]; then
-		>&2 echo "   ⚠️  Detected bash as /bin/sh which is too slow"
-	fi
-}
-
 # get home or id directly from /etc/passwd, replaces id and getent
 _get_sys_info() {
 	case "$1" in
@@ -529,8 +521,6 @@ fi
 
 # check dependencies
 _dep_check $DEPENDENCIES
-
-_check_shell &
 
 # Make sure we always have the real home
 USER="${LOGNAME:-${USER:-${USERNAME}}}"

--- a/sas.sh
+++ b/sas.sh
@@ -251,9 +251,9 @@ _is_appimage() {
 	fi
 
 	# check for dwarfs or squashfs in parallel
-	head -c "$offset" "$1" | grep -aq 'squashfs' -m 1 &
+	head -c "$offset" "$1" | awk '/squashfs/{exit 0} END {exit 1}' &
 	sqfsck=$!
-	head -c "$offset" "$1" | grep -aq 'DWARFS' -m 1 &
+	head -c "$offset" "$1" | awk '/DWARFS/{exit 0} END {exit 1}' &
 	dwfsck=$!
 
 	if wait "$dwfsck"; then

--- a/sas.sh
+++ b/sas.sh
@@ -572,19 +572,19 @@ XDISPLAY="${XAUTHORITY:-$RUNDIR/Xauthority}"
 
 # Default dirs to give read access for working theming
 THEME_DIRS="
-	"$CONFIGDIR"/dconf
-	"$CONFIGDIR"/fontconfig
-	"$CONFIGDIR"/gtk-3.0
-	"$CONFIGDIR"/gtk3.0
-	"$CONFIGDIR"/gtk-4.0
-	"$CONFIGDIR"/gtk4.0
-	"$CONFIGDIR"/kdeglobals
-	"$CONFIGDIR"/Kvantum
-	"$CONFIGDIR"/lxde
-	"$CONFIGDIR"/qt5ct
-	"$CONFIGDIR"/qt6ct
-	"$DATADIR"/icons
-	"$DATADIR"/themes
+	$CONFIGDIR/dconf
+	$CONFIGDIR/fontconfig
+	$CONFIGDIR/gtk-3.0
+	$CONFIGDIR/gtk3.0
+	$CONFIGDIR/gtk-4.0
+	$CONFIGDIR/gtk4.0
+	$CONFIGDIR/kdeglobals
+	$CONFIGDIR/Kvantum
+	$CONFIGDIR/lxde
+	$CONFIGDIR/qt5ct
+	$CONFIGDIR/qt6ct
+	$DATADIR/icons
+	$DATADIR/themes
 "
 
 # do not share X11 by default on wayland

--- a/sas.sh
+++ b/sas.sh
@@ -130,7 +130,7 @@ _get_sys_info() {
 	case "$1" in
 		home) i=6   ;;
 		id)   i=3   ;;
-		*|'') exit 1;;
+		''|*) exit 1;;
 	esac
 	awk -F':' -v U="$USER" -v F="$i" '$1==U {print $F; exit}' /etc/passwd
 }
@@ -595,7 +595,7 @@ fi
 # parse the array
 while :; do
 	case "$1" in
-		--help|-h|-H|'')
+		''|--help|-h|-H)
 			_help
 			;;
 		--version|-v|-V)
@@ -679,7 +679,7 @@ while :; do
 				all)   SHARE_DEV_ALL=1               ;;
 				dri)   SHARE_DEV_DRI=1               ;;
 				input) SHARE_DEV_INPUT=1             ;;
-				*|'') _error "$1 Unknown device '$2'";;
+				''|*) _error "$1 Unknown device '$2'";;
 			esac
 			shift
 			shift
@@ -689,7 +689,7 @@ while :; do
 				all)   SHARE_DEV_ALL=0               ;;
 				dri)   SHARE_DEV_DRI=0               ;;
 				input) SHARE_DEV_INPUT=0             ;;
-				*|'') _error "$1 Unknown device '$2'";;
+				''|*) _error "$1 Unknown device '$2'";;
 			esac
 			shift
 			shift
@@ -704,7 +704,7 @@ while :; do
 				network)    SHARE_APP_NETWORK=1      ;;
 				x11)        SHARE_APP_XDISPLAY=1     ;;
 				wayland)    SHARE_APP_WDISPLAY=1     ;;
-				*|'') _error "$1 Unknown socket '$2'";;
+				''|*) _error "$1 Unknown socket '$2'";;
 			esac
 			shift
 			shift
@@ -719,7 +719,7 @@ while :; do
 				network)    SHARE_APP_NETWORK=0      ;;
 				x11)        SHARE_APP_XDISPLAY=0     ;;
 				wayland)    SHARE_APP_WDISPLAY=0     ;;
-				*|'') _error "$1 Unknown socket '$2'";;
+				''|*) _error "$1 Unknown socket '$2'";;
 			esac
 			shift
 			shift
@@ -753,7 +753,7 @@ while :; do
 		-*)
 			_error "Unknown option: $1"
 			;;
-		*|'')
+		*)
 			if _is_target "$1"; then
 				# We shift and break here to later pass
 				# the rest of the array to $TO_EXEC

--- a/sas.sh
+++ b/sas.sh
@@ -251,10 +251,10 @@ _is_appimage() {
 	fi
 
 	# check for dwarfs or squashfs in parallel
-	head -c "$offset" "$1" | awk '/squashfs/{exit 0} END {exit 1}' &
-	sqfsck=$!
-	head -c "$offset" "$1" | awk '/DWARFS/{exit 0} END {exit 1}' &
+	head -c "$offset" "$1" | grep -aq 'DWARFS' -m 1 &
 	dwfsck=$!
+	head -c "$offset" "$1" | grep -aq 'squashfs' -m 1 &
+	sqfsck=$!
 
 	if wait "$dwfsck"; then
 		DWARFS_APPIMAGE=1

--- a/sas.sh
+++ b/sas.sh
@@ -269,7 +269,7 @@ _check_xdgbase() {
 	for d do
 		eval "d=\$$d"
 		if ! _is_spooky "$d"; then
-			_error "Something is fishy here, bailing out..."
+			return 1
 		fi
 	done
 }
@@ -583,7 +583,8 @@ TEMPLATESDIR="${XDG_TEMPLATES_DIR:-$HOME/Templates}"
 VIDEOSDIR="${XDG_VIDEOS_DIR:-$HOME/Videos}"
 
 # check if any of the xdg vars are set some spooky value
-_check_xdgbase $XDG_BASE_DIRS $XDG_USER_DIRS
+_check_xdgbase $XDG_BASE_DIRS $XDG_USER_DIRS &
+xdgcheck=$!
 
 ZDOTDIR="$(_readlink -f "${ZDOTDIR:-$HOME}")"
 TMPDIR="${TMPDIR:-/tmp}"
@@ -801,6 +802,10 @@ if _is_appimage "$TARGET"; then
 	fi
 else
 	TO_EXEC="$TARGET"
+fi
+
+if ! wait "$xdgcheck"; then
+	_error "Something is fishy here, bailing out..."
 fi
 
 # Save current array and make bwrap array


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95376476-b76e-44d6-8d6b-f79734d96887)

These changes also made it that when `bash` is the `/bin/sh` it isn't 4x slower anymore but only 2x slower 😆 so the warning about slow shell is now removed.

Stopped bundling busybox since performance isn't great, and you still depend on host binaries like umount for this to work anyway. 