### PR TITLE
add option to use FUSE inside sandbox

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -31,6 +31,7 @@ jobs:
         UPINFO="gh-releases-zsync|$(echo $GITHUB_REPOSITORY | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 
         BWRAP_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/bubblewrap/official/bwrap/raw.dl"
+        BWRAP_PATCHED_URL="https://pkgs.pkgforge.dev/dl/bincache/x86_64-linux/bubblewrap/patched/bwrap/raw.dl"
         AWK_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/mawk/mawk/raw.dl"
         SQUASHFUSE_URL="https://pkgs.pkgforge.dev/dl/bincache/$ARCH-linux/squashfuse/nixpkgs/squashfuse/raw.dl"
         
@@ -38,9 +39,10 @@ jobs:
         cp -v ./sas.sh ./AppDir/AppRun
         cd ./AppDir
 
-        wget --retry-connrefused --tries=30 "$AWK_URL"        -O  ./bin/awk
-        wget --retry-connrefused --tries=30 "$BWRAP_URL"      -O  ./bin/bwrap
-        wget --retry-connrefused --tries=30 "$SQUASHFUSE_URL" -O  ./bin/squashfuse
+        wget --retry-connrefused --tries=30 "$AWK_URL"           -O  ./bin/awk
+        wget --retry-connrefused --tries=30 "$BWRAP_URL"         -O  ./bin/bwrap
+        wget --retry-connrefused --tries=30 "$BWRAP_PATCHED_URL" -O  ./bin/bwrap.patched
+        wget --retry-connrefused --tries=30 "$SQUASHFUSE_URL"    -O  ./bin/squashfuse
 
         chmod +x ./AppRun ./bin/*
         

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Supports DwarFS and SquashFS filesystems.
 
 # Usage
 
-`./sas.sh [OPTIONS] /path/to/app`
+`./sas.AppImage [OPTIONS] /path/to/app`
 
 Example:
 
 ```
-./sas.sh --rm-socket network --add-dir ~/"My randomdir" --add-dir xdg-download:rw ./My-random.AppImage
+./sas.AppImage --rm-socket network --add-dir ~/"My randomdir" --add-dir xdg-download:rw ./My-random.AppImage
 ```
 
 Options: 
@@ -29,6 +29,8 @@ Options:
 * `--data-dir`, `--sandboxed-home` specifies the location of the sandboxed home. Otherwise defaults to `ApplicationName.home` next to the application to sandbox.
 
 * `--add-dir`, `--add-file` directory/file to give read access to. In order to add write access add `:rw` to the file, example `--add-dir /media/drive:rw`.
+
+* `--allow-fuse` Enables using FUSE inside the sandbox, only recommended for apps like Steam that need to launch other AppImages. NOTE: Using this option will switch the `bwrap` in the AppImage builds of `sas` to a [patched](https://github.com/VHSgunzo/bubblewrap-static/blob/main/bwrap.patch) bubblewrap that allows nested bwrap sessions.
 
 * `--no-config` Don't use existing configuration files, by default we try to give access to a directory matching the name of the given application in the following locations:  
 
@@ -43,6 +45,7 @@ XDG_DATA_HOME
 ```
 $XDG_DATA_HOME/icons
 $XDG_DATA_HOME/themes
+$XDG_DATA_HOME/fonts
 $XDG_CONFIG_HOME/dconf
 $XDG_CONFIG_HOME/fontconfig
 $XDG_CONFIG_HOME/gtk-3.0

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Options:
 
 * `--add-dir`, `--add-file` directory/file to give read access to. In order to add write access add `:rw` to the file, example `--add-dir /media/drive:rw`.
 
-* `--allow-fuse` Enables using FUSE inside the sandbox, only recommended for apps like Steam that need to launch other AppImages. NOTE: Using this option will switch the `bwrap` in the AppImage builds of `sas` to a [patched](https://github.com/VHSgunzo/bubblewrap-static/blob/main/bwrap.patch) bubblewrap that allows nested bwrap sessions.
+* `--allow-fuse` Enables using FUSE inside the sandbox, only recommended for apps like Steam that need to launch other big AppImages, when this option is NOT used `APPIMAGE_EXTRACT_AND_RUN=1` is set inside the sandbox so that AppImages can still work, albeit less efficiently.
+
+* `--allow-nested-caps` Using this option will switch the `bwrap` in the AppImage builds of `sas` to a [patched](https://github.com/VHSgunzo/bubblewrap-static/blob/main/bwrap.patch) bubblewrap that allows nested bwrap sessions.
 
 * `--no-config` Don't use existing configuration files, by default we try to give access to a directory matching the name of the given application in the following locations:  
 

--- a/sas.sh
+++ b/sas.sh
@@ -400,7 +400,7 @@ _make_bwrap_array() {
 	set -- \
 	  --dir /app                  \
 	  --perms 0700                \
-	  --dir /run/user/"$ID"      \
+	  --dir /run/user/"$ID"       \
 	  --bind "$FAKEHOME" "$HOME"  \
 	  --proc /proc                \
 	  --unshare-user-try          \

--- a/sas.sh
+++ b/sas.sh
@@ -12,7 +12,7 @@ if [ "$SAS_DEBUG" = 1 ]; then
 	set -x
 fi
 
-VERSION=1.0
+VERSION=1.1
 
 ADD_DIR=""
 ALLOW_FUSE=0

--- a/sas.sh
+++ b/sas.sh
@@ -638,9 +638,13 @@ while :; do
 			;;
 		--allow-fuse)
 			ALLOW_FUSE=1
-			# Use patched bwrap that allows nested capabilities
+			shift
+			;;
+		--allow-nested-caps)
 			if command -v bwrap.patched 1>/dev/null; then
 				BWRAPCMD="bwrap.patched"
+			else
+				_error "Missing patched bwrap needed for $1"
 			fi
 			shift
 			;;

--- a/sas.sh
+++ b/sas.sh
@@ -310,7 +310,7 @@ _make_fakehome() {
 		FAKEHOME="$(dirname "$TARGET")/$APPNAME.home"
 	fi
 
-	mkdir -p "$FAKEHOME" 2>/dev/null || true
+	mkdir -p "$FAKEHOME"/.app 2>/dev/null || true
 
 	if ! _is_spooky "$FAKEHOME"; then
 		_error "Cannot use $1 as sandboxed home"
@@ -398,22 +398,23 @@ _make_mountpoint() {
 _make_bwrap_array() {
 	set -u
 	set -- \
-	  --dir /app                  \
-	  --perms 0700                \
-	  --dir /run/user/"$ID"       \
-	  --bind "$FAKEHOME" "$HOME"  \
-	  --proc /proc                \
-	  --unshare-user-try          \
-	  --unshare-pid               \
-	  --unshare-uts               \
-	  --die-with-parent           \
-	  --unshare-cgroup-try        \
-	  --new-session               \
-	  --unshare-ipc               \
-	  --setenv SAS_SANDBOX 1      \
-	  --setenv  TMPDIR  /tmp      \
-	  --setenv  HOME    "$HOME"   \
-	  --ro-bind "$TARGET"   /app/"$APPNAME" \
+	  --dir /app                          \
+	  --perms 0700                        \
+	  --dir /run/user/"$ID"               \
+	  --bind "$FAKEHOME" "$HOME"          \
+	  --bind "$FAKEHOME"/.app /app        \
+	  --ro-bind "$TARGET" /app/"$APPNAME" \
+	  --proc /proc                        \
+	  --unshare-user-try                  \
+	  --unshare-pid                       \
+	  --unshare-uts                       \
+	  --die-with-parent                   \
+	  --unshare-cgroup-try                \
+	  --new-session                       \
+	  --unshare-ipc                       \
+	  --setenv SAS_SANDBOX 1              \
+	  --setenv  TMPDIR  /tmp              \
+	  --setenv  HOME    "$HOME"           \
 	  --setenv XDG_RUNTIME_DIR  /run/user/"$ID"
 
 	if [ "$ALLOW_FUSE" = 1 ]; then

--- a/sas.sh
+++ b/sas.sh
@@ -249,7 +249,8 @@ _is_spooky() {
 }
 
 _is_appimage() {
-	if [ "$SAS_SANDBOX" = 1 ] && [ "$ALLOW_FUSE" = 0 ]; then
+	# do not check if in nested sandbox or allowing fuse
+	if [ "$SAS_SANDBOX" = 1 ] || [ "$ALLOW_FUSE" = 1 ]; then
 		return 1
 	fi
 

--- a/sas.sh
+++ b/sas.sh
@@ -136,7 +136,7 @@ _dep_check() {
 _get_sys_info() {
 	case "$1" in
 		home) i=6   ;;
-		uid)  i=3   ;;
+		id)   i=3   ;;
 		gid)  i=4   ;;
 		''|*) exit 1;;
 	esac
@@ -389,7 +389,7 @@ _make_mountpoint() {
 
 	# common flags for squashfuse and dwarfs
 	set -- \
-	  -o ro,nodev,uid="$UID",gid="$GID" \
+	  -o ro,nodev,uid="$ID",gid="$GID" \
 	  -o offset="$offset" "$TARGET" "$MOUNT_POINT"
 	( squashfuse "$@" 2>/dev/null || dwarfs "$@" ) &
 	mountcheck=$!
@@ -400,7 +400,7 @@ _make_bwrap_array() {
 	set -- \
 	  --dir /app                  \
 	  --perms 0700                \
-	  --dir /run/user/"$UID"      \
+	  --dir /run/user/"$ID"      \
 	  --bind "$FAKEHOME" "$HOME"  \
 	  --proc /proc                \
 	  --unshare-user-try          \
@@ -414,7 +414,7 @@ _make_bwrap_array() {
 	  --setenv  TMPDIR  /tmp      \
 	  --setenv  HOME    "$HOME"   \
 	  --ro-bind "$TARGET"   /app/"$APPNAME" \
-	  --setenv XDG_RUNTIME_DIR  /run/user/"$UID"
+	  --setenv XDG_RUNTIME_DIR  /run/user/"$ID"
 
 	if [ "$ALLOW_FUSE" = 1 ]; then
 		# CAP_SYS_ADMIN needed when allowing FUSE inside sandbox
@@ -469,16 +469,16 @@ _make_bwrap_array() {
 	if [ "$SHARE_APP_DBUS" = 1 ]; then
 		set -- "$@" \
 		  --ro-bind-try /var/lib/dbus  /var/lib/dbus  \
-		  --ro-bind-try "$RUNDIR"/bus  /run/user/"$UID"/bus
+		  --ro-bind-try "$RUNDIR"/bus  /run/user/"$ID"/bus
 	fi
 	if [ "$SHARE_APP_AUDIO" = 1 ]; then
 		set -- "$@" \
 		  --dev-bind-try /dev/snd       /dev/snd \
-		  --ro-bind-try "$RUNDIR"/pulse /run/user/"$UID"/pulse
+		  --ro-bind-try "$RUNDIR"/pulse /run/user/"$ID"/pulse
 	fi
 	if [ "$SHARE_APP_PIPEWIRE" = 1 ]; then
 		set -- "$@" \
-		  --ro-bind-try "$RUNDIR"/pipewire-0 /run/user/"$UID"/pipewire-0
+		  --ro-bind-try "$RUNDIR"/pipewire-0 /run/user/"$ID"/pipewire-0
 	fi
 	if [ "$SHARE_APP_XDISPLAY" = 1 ]; then
 		set -- "$@" \
@@ -489,7 +489,7 @@ _make_bwrap_array() {
 	if [ "$SHARE_APP_WDISPLAY" = 1 ]; then
 		set -- "$@" \
 		  --setenv WAYLAND_DISPLAY wayland-0 \
-		  --ro-bind-try "$RUNDIR"/"$WDISPLAY" /run/user/"$UID"/wayland-0
+		  --ro-bind-try "$RUNDIR"/"$WDISPLAY" /run/user/"$ID"/wayland-0
 	fi
 	if [ "$SHARE_APP_NETWORK" = 1 ]; then
 		set -- "$@" --share-net
@@ -548,18 +548,18 @@ _dep_check $DEPENDENCIES
 USER="${LOGNAME:-${USER:-${USERNAME}}}"
 if [ -f '/etc/passwd' ]; then
 	SAS_HOME="$(_get_sys_info home)"
-	SAS_UID="$(_get_sys_info uid)"
+	SAS_ID="$(_get_sys_info id)"
 	SAS_GID="$(_get_sys_info gid)"
 	# export internal variables this way apps with
 	# restricted access to /etc can still use this
-	export SAS_HOME SAS_UID SAS_GID
+	export SAS_HOME SAS_ID SAS_GID
 fi
 
 HOME="$SAS_HOME"
-UID="$SAS_UID"
+ID="$SAS_ID"
 GID="$SAS_GID"
 
-if [ -z "$USER" ] || [ ! -d "$HOME" ] || [ -z "$UID" ] || [ -z "$GID" ]; then
+if [ -z "$USER" ] || [ ! -d "$HOME" ] || [ -z "$ID" ] || [ -z "$GID" ]; then
 	_error "This system is fucked up"
 fi
 
@@ -569,7 +569,7 @@ DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}"
 CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"
 CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
 STATEDIR="${XDG_STATE_HOME:-$HOME/.local/state}"
-RUNDIR="${XDG_RUNTIME_DIR:-/run/user/$UID}"
+RUNDIR="${XDG_RUNTIME_DIR:-/run/user/$ID}"
 
 # check xdg user dirs
 _check_userdirs || true

--- a/sas.sh
+++ b/sas.sh
@@ -431,19 +431,16 @@ _make_bwrap_array() {
 		set -- "$@" --dev-bind-try /dev  /dev
 	else
 		set -- "$@" --dev /dev
-		if [ "$SHARE_DEV_DRI" = 1 ]; then
-			set -- "$@" \
-			--dev-bind-try /dev/nvidiactl          /dev/nvidiactl       \
-			--dev-bind-try /dev/nvidia0            /dev/nvidia0         \
-			--dev-bind-try /dev/nvidia-modeset     /dev/nvidia-modeset
-		fi
 	fi
 	if [ "$SHARE_DEV_DRI" = 1 ]; then
 		set -- "$@" \
-		--ro-bind-try  /usr/share/glvnd        /usr/share/glvnd     \
-		--ro-bind-try  /usr/share/vulkan       /usr/share/vulkan    \
-		--ro-bind-try  /sys/dev/char           /sys/dev/char        \
-		--ro-bind-try  /sys/devices/pci0000:00 /sys/devices/pci0000:00
+		  --ro-bind-try  /usr/share/glvnd        /usr/share/glvnd     \
+		  --ro-bind-try  /usr/share/vulkan       /usr/share/vulkan    \
+		  --ro-bind-try  /sys/dev/char           /sys/dev/char        \
+		  --dev-bind-try /dev/nvidiactl          /dev/nvidiactl       \
+		  --dev-bind-try /dev/nvidia0            /dev/nvidia0         \
+		  --dev-bind-try /dev/nvidia-modeset     /dev/nvidia-modeset  \
+		  --ro-bind-try  /sys/devices/pci0000:00 /sys/devices/pci0000:00
 	fi
 	if [ "$SHARE_DEV_INPUT" = 1 ]; then
 		set -- "$@" --ro-bind  /sys/class/input  /sys/class/input


### PR DESCRIPTION
fixes #27 

@germaniuss Can you test this and let me know if the nvidia thingy works? 

I'm not sure if this also fixes the `xdg-open` issue, so in any case set `RIM_HOST_XDG_OPEN=0` if that still does not work.

[build artifact](https://github.com/Samueru-sama/simple-appimage-sandbox/actions/runs/16738203507)


**EDIT:** Forgot to mention, to use this option you need to pass an extra flag in the sandbox script `--allow-fuse`