### PR TITLE
feat: support seccomp filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Options:
 
 * `--allow-nested-caps` Using this option will switch the `bwrap` in the AppImage builds of `sas` to a [patched](https://github.com/VHSgunzo/bubblewrap-static/blob/main/bwrap.patch) bubblewrap that allows nested bwrap sessions.
 
+* `--seccomp FILE` Apply a compiled seccomp BPF filter to the sandbox. The file must use the format produced by `seccomp_export_bpf`.
+
 * `--no-config` Don't use existing configuration files, by default we try to give access to a directory matching the name of the given application in the following locations:  
 
 ```

--- a/sas.sh
+++ b/sas.sh
@@ -35,6 +35,7 @@ ALLOW_TEMPLATESDIR=0
 ALLOW_VIDEOSDIR=0
 
 BWRAPCMD="bwrap"
+SECCOMP_FILTER=""
 
 SHARE_APP_CONFIG=1
 SHARE_APP_THEME=1
@@ -724,6 +725,15 @@ while :; do
 			ALLOW_FUSE=1
 			shift
 			;;
+		--seccomp)
+			case "$2" in
+				''|-*) _error "No seccomp filter given to $1";;
+			esac
+			[ -r "$2" ] || _error "Cannot read seccomp filter '$2'"
+			SECCOMP_FILTER="$(_readlink -f "$2")"
+			shift
+			shift
+			;;
 		--allow-nested-caps)
 			if command -v bwrap.patched 1>/dev/null; then
 				BWRAPCMD="bwrap.patched"
@@ -949,4 +959,8 @@ if [ -n "$SAS_XDG_OPEN_DAEMON" ]; then
 fi
 
 # Do the thing!
-"$BWRAPCMD" "$@"
+if [ -n "$SECCOMP_FILTER" ]; then
+	"$BWRAPCMD" --seccomp 3 "$@" 3<"$SECCOMP_FILTER"
+else
+	"$BWRAPCMD" "$@"
+fi


### PR DESCRIPTION
Bubblewrap supports seccomp filters for restricting which system calls are available inside the sandbox: https://github.com/containers/bubblewrap#sandboxing

This adds `--seccomp FILE`. The compiled BPF filter is opened on a file descriptor and passed directly to Bubblewrap using its `--seccomp` option.